### PR TITLE
Use new core auth sdk 1.0.2 in sample apps

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
 github "AFNetworking/AFNetworking" == 4.0.1
 github "soheilbm/Base64" "67083ec1e3e970ec920cbf126e6957c6e9e88ae4"
 binary "https://iovation.github.io/deviceprint-SDK-iOS/FraudForce.json" == 5.0.3
-binary "https://iovation.github.io/launchkey-ios-authenticator-sdk/CoreAuthenticator/CoreAuthenticator.json" == 1.0.1
+binary "https://iovation.github.io/launchkey-ios-authenticator-sdk/CoreAuthenticator/CoreAuthenticator.json" == 1.0.2

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 binary "https://iovation.github.io/deviceprint-SDK-iOS/FraudForce.json" "5.0.3"
-binary "https://iovation.github.io/launchkey-ios-authenticator-sdk/CoreAuthenticator/CoreAuthenticator.json" "1.0.1"
+binary "https://iovation.github.io/launchkey-ios-authenticator-sdk/CoreAuthenticator/CoreAuthenticator.json" "1.0.2"
 github "AFNetworking/AFNetworking" "4.0.1"
 github "soheilbm/Base64" "67083ec1e3e970ec920cbf126e6957c6e9e88ae4"


### PR DESCRIPTION
Updated cartfile to pull in the new core sdk v1.0.2.